### PR TITLE
make sure vaildation service works

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-WEBSITE_PING="http://cjhawley.com/ping"
+WEBSITE_PING="https://cjhawley.com/ping"
 
 response_code=$(curl -w %{http_code} -s -o /dev/null ${WEBSITE_PING})
 


### PR DESCRIPTION
After enabling TLS, curls to `http://cjhawley.com` are redirected to `https://cjhawley.com`, so the validation script returned a `301` redirect code. 

Changing the validation script to test `https://cjhawley.com` instead.