### PR TITLE
remove skip from page

### DIFF
--- a/src/main/resources/web/jsp/index.vm
+++ b/src/main/resources/web/jsp/index.vm
@@ -51,7 +51,7 @@
   
         <div style="float:left; margin-top: 40px; width:75%">
           <p>Hi, I'm Chris. (<a href="/resume/resume.html" style="text-decoration: underline; color: black;">View my resume</a>)</p>
-          <p>I develop software for <a href="https://goradar.com" style="text-decoration: underline; color: black;">RADAR</a> (formerly Skip). I'm a backend engineer primarily focusing on building large scale systems, but am also interested in many computer vision topics.</p>
+          <p>I develop software for <a href="https://goradar.com" style="text-decoration: underline; color: black;">RADAR</a>. I'm a backend engineer primarily focusing on building large scale systems, but am also interested in many computer vision topics.</p>
         </div>
 
         <div style="width:75%;">


### PR DESCRIPTION
This PR removes `formerly skip` from the front page, as there should no longer be any confusion.